### PR TITLE
App Cleanup

### DIFF
--- a/app-template/index.rst
+++ b/app-template/index.rst
@@ -18,7 +18,9 @@ Overview
      -
    * - Criticality Level
      -
-   * - GitHub Repository
+   * - GitHub Application Code Repository
+     -
+   * - GitHub Deployment Repository
      -
    * - Slack Support channel
      -

--- a/docs/usdf-applications/ap/alert-archive/index.rst
+++ b/docs/usdf-applications/ap/alert-archive/index.rst
@@ -20,9 +20,13 @@ API that provides an archive to Alert Stream schemas and alerts.
      - Daytime
    * - Criticality Level
      - Critical
-   * - GitHub Repository
+   * - GitHub Application Code Repository
      - https://github.com/lsst-dm/alert_database_server
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     - https://github.com/lsst-sqre/phalanx/tree/main/applications/alert-stream-broker
+   * - Slack Support Channel
+     -
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      -

--- a/docs/usdf-applications/ap/minor-planet-center-replica/index.rst
+++ b/docs/usdf-applications/ap/minor-planet-center-replica/index.rst
@@ -20,11 +20,15 @@ The USDF replica is also setup as a publication and EPO in Google Cloud subscrib
    * - Operating Hours
      - 24x7
    * - Criticality Level
-     - Real-time
-   * - GitHub Repository
+     - Real Time
+   * - GitHub Database Code Repository
      - https://github.com/slaclab/rubin-usdf-minor-planet-survey
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     - https://github.com/slaclab/rubin-usdf-minor-planet-survey
+   * - Slack Support Channel
      - ops-df-databases
+   * - Slack Alerts Channel
+     - ops-usdf-alerts
    * - Prod vCluster
      - usdf-minor-planet-survey
    * - Dev vCluster

--- a/docs/usdf-applications/ap/minor-planet-center-replica/info.rst
+++ b/docs/usdf-applications/ap/minor-planet-center-replica/info.rst
@@ -37,8 +37,6 @@ Configuration Location
 ======================
 .. Detail where the configuration is stored.  This is typically in GitHub, Kubernetes Configuration Maps, and/or Vault Secrets.
 
-`here <https://github.com/slaclab/rubin-usdf-minor-planet-survey/tree/main/kubernetes/overlays/prod/sql>`__
-
 .. list-table::
    :widths: 25 25
    :header-rows: 1

--- a/docs/usdf-applications/ap/mpc-sandbox/index.rst
+++ b/docs/usdf-applications/ap/mpc-sandbox/index.rst
@@ -17,13 +17,17 @@ During commissioning, Rubin will send data to a private, Rubin-only, submission 
    * - Application Grouping
      - Alert Production
    * - Operating Hours
-     -
+     - PDT Daytime
    * - Criticality Level
-     -
-   * - GitHub Repository
+     - Operational
+   * - GitHub Database Code Repository
      - https://github.com/slaclab/rubin-usdf-minor-planet-survey
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     - https://github.com/slaclab/rubin-usdf-minor-planet-survey
+   * - Slack Support Channel
      - ops-df-databases
+   * - Slack Alerts Channel
+     - ops-usdf-alerts
    * - Prod vCluster
      - usdf-minor-planet-survey
    * - Dev vCluster

--- a/docs/usdf-applications/ap/next-visit-fan-out/index.rst
+++ b/docs/usdf-applications/ap/next-visit-fan-out/index.rst
@@ -18,11 +18,15 @@ Poll next visit events from Summit, duplicate them, and sends them to :doc:`../p
    * - Operating Hours
      - Observing
    * - Criticality Level
-     -
-   * - GitHub Repository
+     - Real Time
+   * - GitHub Application Code Repository
      - https://github.com/lsst-dm/next_visit_fan_out
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     - https://github.com/lsst-sqre/phalanx/tree/main/applications/next-visit-fan-out
+   * - Slack Support Channel
      - lsstcam-prompt-processing
+   * - Slack Alerts Channel
+     -
    * - Prod vCluster
      - usdf-prompt-processing
    * - Dev vCluster

--- a/docs/usdf-applications/ap/prompt-kafka/index.rst
+++ b/docs/usdf-applications/ap/prompt-kafka/index.rst
@@ -18,11 +18,15 @@ Kafka Cluster that receives file arrival notifications from the rubin summit S3 
    * - Operating Hours
      - Observing
    * - Criticality Level
-     -
-   * - GitHub Repository
+     - Real Time
+   * - GitHub Application Code Repository
+     - N/A
+   * - GitHub Deployment Repository
      - https://github.com/lsst-sqre/phalanx/tree/main/applications/prompt-kafka
-   * - Slack Support channel
+   * - Slack Support Channel
      - lsstcam-prompt-processing
+   * - Slack Alerts Channel
+     -
    * - Prod vCluster
      - usdf-prompt-processing
    * - Dev vCluster

--- a/docs/usdf-applications/ap/prompt-keda/index.rst
+++ b/docs/usdf-applications/ap/prompt-keda/index.rst
@@ -6,7 +6,7 @@ Overview
 ========
 .. Include short summary of application, service, or database
 
-Autoscaler for Prompt Processing that creates jobs as Next Visit Fanned Out Events arrive.  KEDA stands for Kubernetes Event-driven Autoscaling
+Autoscaler for Prompt Processing that creates jobs as Next Visit Fanned Out Events arrive.  KEDA stands for Kubernetes Event-driven Autoscaling.
 
 .. Include Application Grouping, Operating Hours (24x7, PST daytime, or observing), Criticality Level, a link to the GitHub repository, and Slack channel used for support of the application.
 
@@ -18,11 +18,15 @@ Autoscaler for Prompt Processing that creates jobs as Next Visit Fanned Out Even
    * - Operating Hours
      - Observing
    * - Criticality Level
-     -
-   * - GitHub Repository
+     - Real Time
+   * - GitHub Application Code Repository
+     - N/A
+   * - GitHub Deployment Repository
      - https://github.com/lsst-sqre/phalanx/tree/main/applications/keda
-   * - Slack Support channel
+   * - Slack Support Channel
      - lsstcam-prompt-processing
+   * - Slack Alerts Channel
+     -
    * - Prod vCluster
      - usdf-prompt-processing
    * - Dev vCluster

--- a/docs/usdf-applications/ap/prompt-processing/index.rst
+++ b/docs/usdf-applications/ap/prompt-processing/index.rst
@@ -17,11 +17,15 @@ Overview
    * - Operating Hours
      - Observing
    * - Criticality Level
-     -
-   * - GitHub Repository
+     - Real Time
+   * - GitHub Application Code Repository
      - https://github.com/lsst-dm/prompt_processing
-   * - Slack Support channel
+   * - GitHub Deployment Code Repository
+     - https://github.com/lsst-sqre/phalanx/tree/main/applications/prompt-keda-lsstcam
+   * - Slack Support Channel
      - lsstcam-prompt-processing
+   * - Slack Alerts Channel
+     -
    * - Prod vCluster
      - usdf-prompt-processing
    * - Dev vCluster

--- a/docs/usdf-applications/ap/prompt-redis/index.rst
+++ b/docs/usdf-applications/ap/prompt-redis/index.rst
@@ -18,11 +18,15 @@ Redis Cluster that receives Fanned Out events from :doc:`../next-visit-fan-out/i
    * - Operating Hours
      - Observing
    * - Criticality Level
-     -
-   * - GitHub Repository
+     - Real Time
+   * - GitHub Application Code Repository
+     - N/A
+   * - GitHub Deployment Repository
      - https://github.com/lsst-sqre/phalanx/tree/main/applications/prompt-redis
-   * - Slack Support channel
+   * - Slack Support Channel
      - lsstcam-prompt-processing
+   * - Slack Alerts Channel
+     -
    * - Prod vCluster
      - usdf-prompt-processing
    * - Dev vCluster

--- a/docs/usdf-applications/ap/sattle/index.rst
+++ b/docs/usdf-applications/ap/sattle/index.rst
@@ -20,14 +20,18 @@ This application manages the catalog of satellite orbits that is used to filter 
      - Observing
    * - Criticality Level
      - Real Time
-   * - GitHub Repository
+   * - GitHub Application Code Repository
      - https://github.com/lsst-dm/sattle
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     - https://github.com/lsst-dm/sattle
+   * - Slack Support Channel
+     -
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      - Not applicable.  Installed on S3DF servers.
    * - Dev vCluster
-     - Installed on S3DF servers.
+     - Not applicable.  Installed on S3DF servers.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/usdf-applications/drp/cm-service/documentation-training.rst
+++ b/docs/usdf-applications/drp/cm-service/documentation-training.rst
@@ -2,3 +2,5 @@
 Documentation and Training
 ##########################
 .. Links to other documentation sites and training if available
+
+`CM Service Tech Note <https://dmtn-309.lsst.io/>`__

--- a/docs/usdf-applications/drp/cm-service/index.rst
+++ b/docs/usdf-applications/drp/cm-service/index.rst
@@ -17,9 +17,13 @@ Overview
      - 24x7
    * - Criticality Level
      - Operational
-   * - GitHub Repository
+   * - GitHub Application Code Repository
+     - https://github.com/lsst-dm/cm-service
+   * - GitHub Deployment Repository
+     - https://github.com/lsst-sqre/phalanx/tree/main/applications/cm-service
+   * - Slack Support Channel
      -
-   * - Slack Support channel
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      - usdf-cm

--- a/docs/usdf-applications/drp/fits/index.rst
+++ b/docs/usdf-applications/drp/fits/index.rst
@@ -13,14 +13,18 @@ Overview
    :widths: 25 50
 
    * - Application Grouping
-     - Data Release
+     - Data Release Production
    * - Operating Hours
      - 24x7
    * - Criticality Level
+     - Critical
+   * - GitHub Application Repository
      -
-   * - GitHub Repository
+   * - GitHub Deployment Repository
      -
-   * - Slack Support channel
+   * - Slack Support Channel
+     -
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      -

--- a/docs/usdf-applications/drp/htcondor/index.rst
+++ b/docs/usdf-applications/drp/htcondor/index.rst
@@ -18,9 +18,13 @@ Overview
      - 24x7
    * - Criticality Level
      - Critical
-   * - GitHub Repository
+   * - GitHub Application Repository
      -
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     -
+   * - Slack Support Channel
+     -
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      - Not applicable.  Installed on IANA nodes.

--- a/docs/usdf-applications/drp/opensearch/index.rst
+++ b/docs/usdf-applications/drp/opensearch/index.rst
@@ -18,11 +18,13 @@ Overview
      -
    * - Criticality Level
      -
-   * - GitHub Repository
+   * - GitHub Application Code Repository
      -
-   * - Slack Support channel
+   * - GitHub Deployment Repository
      -
-   * - Slack Alerts channel
+   * - Slack Support Channel
+     -
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      -

--- a/docs/usdf-applications/drp/panda/index.rst
+++ b/docs/usdf-applications/drp/panda/index.rst
@@ -18,10 +18,14 @@ Overview
      - 24x7
    * - Criticality Level
      - Critical
-   * - GitHub Repository
+   * - GitHub Application Code Repository
+     -
+   * - GitHub Deployment Repository
      - https://github.com/slaclab/rubin-usdf-panda-deploy
-   * - Slack Support channel
-     - ops-df-databases
+   * - Slack Support Channel
+     - rubinobs-panda-support for the application.  ops-df-databases for the databases.
+   * - Slack Alerts Channel
+     - ops-usdf-alerts for the databases.
    * - Prod vCluster
      - usdf-panda
    * - Dev vCluster

--- a/docs/usdf-applications/drp/rucio/index.rst
+++ b/docs/usdf-applications/drp/rucio/index.rst
@@ -16,10 +16,14 @@ Overview
    * - Operating Hours
      - 24x7
    * - Criticality Level
+     - Critical
+   * - GitHub Application Code Repository
      -
-   * - GitHub Repository
+   * - GitHub Deployment Repository
      -
-   * - Slack Support channel
+   * - Slack Support Channel
+     - df-data-movement
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      - usdf-rucio

--- a/docs/usdf-applications/qa/rubintv/index.rst
+++ b/docs/usdf-applications/qa/rubintv/index.rst
@@ -20,14 +20,18 @@ Real-time display of images from the summit.
      - 24x7
    * - Criticality Level
      - Operational
-   * - GitHub Repository
+   * - GitHub Application Code Repository
      - https://github.com/lsst-ts/rubintv
-   * - Slack Support channel
+   * - GitHub Deployment Repository
+     - https://github.com/lsst-sqre/phalanx/tree/main/applications/rubintv
+   * - Slack Support Channel
      - sitcom-rubintv-backend in Discovery Alliance Slack
+   * - Slack Alerts Channel
+     -
    * - Prod vCluster
-     - usdf-rapid-analysis
+     - usdf-rsp
    * - Dev vCluster
-     - usdf-rapid-analysis-dev
+     - usdf-rsp-dev
 
 .. toctree::
    :maxdepth: 2

--- a/docs/usdf-applications/qa/summit-db-replica/index.rst
+++ b/docs/usdf-applications/qa/summit-db-replica/index.rst
@@ -20,10 +20,14 @@ The consolidated database, exposurelog, narrativelog, and nightreport Postgres d
      - 24x7
    * - Criticality Level
      -
-   * - GitHub Repository
+   * - GitHub Application Code Repository
+     - Refer to the ConsDB and ExposureLog/NarrativeLog applications
+   * - GitHub Deployment Repository
      - https://github.com/slaclab/rubin-usdf-summit-db-replica-deploy
-   * - Slack Support channel
+   * - Slack Support Channel
      - ops-df-databases
+   * - Slack Alerts Channel
+     - ops-usdf-alerts
    * - Prod vCluster
      - usdf-summitb
    * - Dev vCluster

--- a/docs/usdf-applications/rsp/qserv/index.rst
+++ b/docs/usdf-applications/rsp/qserv/index.rst
@@ -19,14 +19,14 @@ Qserv is an open source, massively parallel, distributed SQL database designed t
    * - Operating Hours
      - 24x7
    * - Criticality Level
-     - Real-time
+     - Real Time
    * - GitHub Application Code Repository
      - https://github.com/lsst/qserv
    * - GitHub Deployment Repository
      - https://github.com/lsst-dm/qserv-slac
-   * - Slack Support channel
+   * - Slack Support Channel
      - usdf-rsp-support
-   * - Slack Alerts channel
+   * - Slack Alerts Channel
      -
    * - Prod vCluster
      -


### PR DESCRIPTION
Add Slack Alerts Channel section to all apps.  Broke out application code and deployment code sections.   Fixes syntax and added links to tech notes.