### PR TITLE
Update APDB service documentation

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -16,6 +16,12 @@ linkcheck_ignore = [
     r'https://slactraining.skillport.com.+',
 ]
 
+# Reducing number of workers from 5 to 1 seems to result in fewer timeouts.
+linkcheck_workers = 1
+
+# Increase number of retries if timeouts still happen.
+linkcheck_retries = 3
+
 # disable TLS verification
 
 tls_verify = False

--- a/docs/usdf-applications/ap/apdb/documentation-training.rst
+++ b/docs/usdf-applications/ap/apdb/documentation-training.rst
@@ -3,4 +3,6 @@ Documentation and Training
 ##########################
 .. Links to other documentation sites and training if available
 
-To be completed...
+Most management operations are implemented as Ansible playbooks in ``dax_apdb_deploy`` package.
+Its `README <https://github.com/lsst-dm/dax_apdb_deploy/blob/main/README.md>`_ file documents typical procedures.
+There is also `playbook documentation <https://github.com/lsst-dm/dax_apdb_deploy/blob/main/cassandra_cluster/README.md>`_ describing uses of individual playbooks.

--- a/docs/usdf-applications/ap/apdb/index.rst
+++ b/docs/usdf-applications/ap/apdb/index.rst
@@ -25,13 +25,15 @@ This database is used by Alert Production that runs as a part of Prompt Producti
    * - GitHub Deployment Repository
      - https://github.com/lsst-dm/dax_apdb_deploy
    * - Slack Support Channel
-     -
+     - #apdb-ppdb-planning
    * - Slack Alerts Channel
-     - ops-apdb-alerts
+     - #ops-apdb-alerts
    * - Prod hosts
      - sdfk8sk001-006
    * - Dev nodes
      - sdfk8sk007-012
+   * - Int nodes
+     - sdfcasdev001-003,101,102
 
 .. toctree::
    :maxdepth: 2

--- a/docs/usdf-applications/ap/apdb/info.rst
+++ b/docs/usdf-applications/ap/apdb/info.rst
@@ -9,7 +9,8 @@ Architecture
 The central component of APDB is `Apache Cassandra database <https://cassandra.apache.org/>`_.
 The database serves approximately 200 clients of Prompt Processing system concurrently reading and writing to the database.
 Cassandra stores its data on fast local storage (NVMe disks in raidz2 array).
-Presently there are 12 nodes at USDF (sdfk8sk001-012) split between two Cassandra clusters.
+Presently there are 12 nodes at USDF (sdfk8sk001-012) split between two Cassandra clusters (``prod`` and ``dev``).
+Additional integration cluster (``int``) uses five extra nodes (sdfcasdev001-003 and sdfcasdev101-102).
 
 Backups of the Cassandra files are managed by `cassandra-medusa <https://github.com/thelastpickle/cassandra-medusa>`_ service running on each cluster node.
 Backups are stored in S3 bucket, off-site storage of backups is not implemented yet.
@@ -22,11 +23,20 @@ Architecture Diagram
 
 .. mermaid::
 
-  flowchart LR
+  flowchart TD
           pp@{ shape: procs, label: "Prompt<br/>Processing" }
-          pp <--> c8@{ shape: procs, label: "Cassandra"}
-          c8 <--> disk@{ shape: lin-cyl, label: "Local<br/>storage" }
-          disk <--> medusa@{ shape: procs, label: "Medusa<br/>backup" }
+          daytime@{ shape: procs, label: "Daytime<br/>Catchup" }
+          dedup@{ shape: proc, label: "Dedup" }
+          subgraph Cassandra Node x N
+            c8@{ shape: proc, label: "Cassandra"}
+            disk@{ shape: lin-cyl, label: "Local<br/>storage" }
+            medusa@{ shape: proc, label: "Medusa<br/>backup" }
+            c8 <--> disk
+            disk --> medusa
+          end
+          pp <--> c8
+          daytime <--> c8
+          dedup <--> c8
           medusa <--> S3disk@{ shape: lin-cyl, label: "S3 Bucket" }
           c8 --> replication["Replication"]
           replication --> ppdb[("PPDB")]
@@ -35,7 +45,8 @@ Replication process is an application separate from APDB.
 
 Associated Systems
 ==================
-.. Describe other applications are associated with this applications.
+
+- :doc:`../prompt-processing/index`
 
 Configuration Location
 ======================
@@ -57,6 +68,8 @@ Configuration Location
      - rubin/usdf-apdb-prod/apdb-prod
    * - Vault Secrets Prod (superuser)
      - rubin/usdf-apdb-prod/cassandra-super
+   * - Vault Secrets for S3
+     - rubin/usdf-apdb-prod/s3
 
 Data Flow
 =========
@@ -65,8 +78,10 @@ Data Flow
 - Prompt Processing jobs query APDB for the pre-existing data in the region covered by visit-detector.
 - Based on the images and pre-existing data Prompt Processing generates a set of records that it saves to Cassandra.
 - This repeats for every visit during the night, approx 1k vistits are expected during the nitght.
+- Daytime catchup processing works similarly to Prompt Processing working on images that failed to process during the night.
+- Deduplication process also runs during daytime, it analyzes records generated during the night and performs cleanup on some of them.
 - Newly generated data are copied from Cassandra periodically by a replication process.
-- Backups are taken perdiodically (once a day or more frequently) and uploaded to an S3 bucket.
+- Backups are taken perdiodically once a day and are uploaded to an S3 bucket.
 - Off-site backup is not implemented yet.
 
 Dependencies - S3DF
@@ -80,7 +95,7 @@ Dependencies - External
 =======================
 .. Dependencies on systems external to S3DF including in US DAC, France or UK DF, or other external systems.  This can be none.
 
-None.
+Off-site backup, which is not implemented yet, will likely depend on some external S3 service.
 
 Disaster Recovery
 =================
@@ -90,3 +105,4 @@ In case of disaster the content of database can be restored from the latest back
 Recovery procedure consists of running ``medusa-cassandra`` service in a special recovery mode which copies data from S3 to the Cassandra hosts.
 Cassandra cluster needs to be configured with the same number of nodes and preferrably with the same IPs.
 Recovery of the data from S3 depends on the amount of data and location of backup (on-site vs off-site) and it could take anywhere between few hours and a day or longer.
+``dax_apdb_deploy`` `README <https://github.com/lsst-dm/dax_apdb_deploy#restoring-backups>`_ documents recovery procedure.

--- a/docs/usdf-applications/ap/apdb/info.rst
+++ b/docs/usdf-applications/ap/apdb/info.rst
@@ -65,9 +65,11 @@ Configuration Location
    * - Vault Secrets Dev (superuser)
      - rubin/usdf-apdb-dev/cassandra-super
    * - Vault Secrets Prod
-     - rubin/usdf-apdb-prod/apdb-prod
+     - rubin/usdf-apdb-prod/cassandra
    * - Vault Secrets Prod (superuser)
      - rubin/usdf-apdb-prod/cassandra-super
+   * - S3 bucket for backups
+     - usdf-apdb-prod
    * - Vault Secrets for S3
      - rubin/usdf-apdb-prod/s3
 
@@ -77,11 +79,11 @@ Data Flow
 
 - Prompt Processing jobs query APDB for the pre-existing data in the region covered by visit-detector.
 - Based on the images and pre-existing data Prompt Processing generates a set of records that it saves to Cassandra.
-- This repeats for every visit during the night, approx 1k vistits are expected during the nitght.
+- This repeats for every visit during the night, approximately 1k visits are expected during each night.
 - Daytime catchup processing works similarly to Prompt Processing working on images that failed to process during the night.
 - Deduplication process also runs during daytime, it analyzes records generated during the night and performs cleanup on some of them.
 - Newly generated data are copied from Cassandra periodically by a replication process.
-- Backups are taken perdiodically once a day and are uploaded to an S3 bucket.
+- Backups are taken periodically once a day and are uploaded to an S3 bucket.
 - Off-site backup is not implemented yet.
 
 Dependencies - S3DF
@@ -103,6 +105,6 @@ Disaster Recovery
 
 In case of disaster the content of database can be restored from the latest backup.
 Recovery procedure consists of running ``medusa-cassandra`` service in a special recovery mode which copies data from S3 to the Cassandra hosts.
-Cassandra cluster needs to be configured with the same number of nodes and preferrably with the same IPs.
+Cassandra cluster needs to be configured with the same number of nodes and preferably with the same IPs.
 Recovery of the data from S3 depends on the amount of data and location of backup (on-site vs off-site) and it could take anywhere between few hours and a day or longer.
 ``dax_apdb_deploy`` `README <https://github.com/lsst-dm/dax_apdb_deploy#restoring-backups>`_ documents recovery procedure.

--- a/docs/usdf-applications/ap/apdb/info.rst
+++ b/docs/usdf-applications/ap/apdb/info.rst
@@ -50,11 +50,13 @@ Configuration Location
    * - Configuration
      - https://github.com/lsst-dm/dax_apdb_deploy
    * - Vault Secrets Dev
-     - | rubin/usdf-apdb-test/cassandra-super
-       | rubin/usdf-apdb-test/cassandra
+     - rubin/usdf-apdb-dev/cassandra
+   * - Vault Secrets Dev (superuser)
+     - rubin/usdf-apdb-dev/cassandra-super
    * - Vault Secrets Prod
-     - | rubin/usdf-apdb-dev/cassandra-super
-       | rubin/usdf-apdb-dev/apdb-prod
+     - rubin/usdf-apdb-prod/apdb-prod
+   * - Vault Secrets Prod (superuser)
+     - rubin/usdf-apdb-prod/cassandra-super
 
 Data Flow
 =========

--- a/docs/usdf-applications/ap/apdb/info.rst
+++ b/docs/usdf-applications/ap/apdb/info.rst
@@ -11,7 +11,7 @@ The database serves approximately 200 clients of Prompt Processing system concur
 Cassandra stores its data on fast local storage (NVMe disks in raidz2 array).
 Presently there are 12 nodes at USDF (sdfk8sk001-012) split between two Cassandra clusters.
 
-Backups of the Cassandra files are managed by `cassandra-meduza <https://github.com/thelastpickle/cassandra-medusa>`_ service running on each cluster node.
+Backups of the Cassandra files are managed by `cassandra-medusa <https://github.com/thelastpickle/cassandra-medusa>`_ service running on each cluster node.
 Backups are stored in S3 bucket, off-site storage of backups is not implemented yet.
 
 A separate application reads data from APDB and replicates it to PPDB, which will likely be implemented on top of Google BigQuery.
@@ -21,7 +21,6 @@ Architecture Diagram
 .. Include architecture diagram of the application either as a mermaid chart or a picture of the diagram.
 
 .. mermaid::
-  :config: {"theme": "neutral"}
 
   flowchart LR
           pp@{ shape: procs, label: "Prompt<br/>Processing" }

--- a/docs/usdf-applications/ap/apdb/procedures.rst
+++ b/docs/usdf-applications/ap/apdb/procedures.rst
@@ -30,7 +30,7 @@ Maintenance
 ===========
 .. Maintenance tasks. How maintenance is communicated and carried out.
 
-Maintenance operations that could impact APDB availability need to be announced on ``dm-prompt-processing-dev`` Slack channel in advance.
+Maintenance operations that could impact APDB availability need to be announced on ``#dm-prompt-processing-dev`` Slack channel in advance.
 
 Operations that involve CQL queries (e.g. altering keyspace or table properties) need to be executed on one of the cluster nodes.
 There is a ``cqlsh`` wrapper script installed in a Docker deployment directory on each cluster node.

--- a/docs/usdf-applications/ap/apdb/procedures.rst
+++ b/docs/usdf-applications/ap/apdb/procedures.rst
@@ -4,8 +4,18 @@ Procedures
 
 Intended audience: Anyone who is administering APDB.
 
-The `dax_apdb_deploy <https://github.com/lsst-dm/dax_apdb_deploy/>`_ package implements deployment and management procedues based on ``Ansible``.
+The `dax_apdb_deploy <https://github.com/lsst-dm/dax_apdb_deploy/>`_ package implements deployment and management procedures based on ``Ansible``.
 Details of operations are documented in its `README <https://github.com/lsst-dm/dax_apdb_deploy/blob/main/README.md>`_ file.
+
+``dax_apdb_deploy`` needs to be cloned to a user's directory on any ``rubin-devl`` machine and setup:
+
+.. code-block:: bash
+
+   cd somewhere
+   git clone git@github.com:lsst-dm/dax_apdb_deploy.git
+   cd dax_apdb_deploy
+   make setup
+   . ./setup.sh
 
 Deployment
 ==========
@@ -14,13 +24,46 @@ Deployment
 Deployment of a new Cassandra cluster consists of defining a set of parameters for the new instance.
 This is done by adding a new group to ``group_vars`` folder and a new inventory YAML file.
 Additionally new secrets need to be setup in the Vault for both a standard user account and superuser account.
-Once the group and inventory are defined one needs to run a series of ansible roleplays to configure remote systems and brign up all services.
+Once the group and inventory are defined one needs to run a `series of Ansible playbooks <https://github.com/lsst-dm/dax_apdb_deploy/blob/main/README.md#bootstrapping-a-new-cluster>`_ to configure remote systems and bring up all services.
 
 Maintenance
 ===========
 .. Maintenance tasks. How maintenance is communicated and carried out.
 
-To be completed...
+Maintenance operations that could impact APDB availability need to be announced on ``dm-prompt-processing-dev`` Slack channel in advance.
+
+Operations that involve CQL queries (e.g. altering keyspace or table properties) need to be executed on one of the cluster nodes.
+There is a ``cqlsh`` wrapper script installed in a Docker deployment directory on each cluster node.
+
+.. code-block:: bash
+
+   ssh rubincas@sdfk8sk001
+   cd apdb_deploy/docker
+   # Some operations may need superuser access. Cqlsh will prompt for a password.
+   ./cqlsh -u superuser
+   Password:
+   cqlsh> DESCRIBE KEYSPACES
+   cqlsh> ...
+
+Tasks that use ``nodetool`` command can be run from ``dax_apdb_deploy`` using its ``ansible-pssh`` command, e.g.:
+
+.. code-block:: bash
+
+   # -d means to change to docker deployment directory before running the command.
+   # -1 means execute command on a single cluster node, default is to run on all nodes.
+   ansible-pssh -i inventory/apdb_prod.yaml -d -1 "./nodetool status"
+
+Periodic maintenance tasks are executed by cron jobs from user's account (currently ``salnikov``).
+Scripts used by the cron jobs are located in `dax_apdb_deploy/tree/main/etc/cron <https://github.com/lsst-dm/dax_apdb_deploy/tree/main/etc/cron>`_ directory.
+Cron jobs use pre-installed ``dax_apdb_deploy`` location in user's home directory.
+
+Presently there are a few periodic cron jobs:
+
+- backups of the ``prod`` Cassandra cluster (daily/weekly/monthly/yearly) (etc/cron/backup-job.sh)
+- backups of the ``dev`` Cassandra cluster (daily/weekly) (etc/cron/backup-job.sh)
+- cleanup of the old backups (etc/cron/backup-cleanup-job.sh)
+- cluster repair (twice a week) (etc/cron/repair-job.sh)
+- check of cluster connection status by checking Cassandra port on each node (every 10 minutes)
 
 Backup
 ======
@@ -30,7 +73,12 @@ Backup operations are based on ``cassandra-medusa`` service that runs on every n
 Location of the backups on S3 is configured in the ``group_vars``.
 The ``medusa-backup`` CLI is implemented to make and manage backups.
 
-Taking backups is not automated yet.
+Backups of the production cluster happen daily at 7:00 USDF time.
+In addition to daily backups there are weekly, monthly, and yearly backups.
+We keep 10 latest daily backups, 8 weekly backups, and 12 monthly backups.
+Yearly backups will be kept forever in case we will need to access data that was removed.
+
+Each backup created by ``cassandra-medusa`` is a full backup, but backups use deduplication.
 
 Cold Startup
 ============
@@ -38,18 +86,17 @@ Cold Startup
 
 The services run in docker containers and will restart automatically after downtime.
 Recovery from a disaster involves additional steps to restore data files from S3 to local filesystem.
-
-To be documented...
+Restore procedure is documented in ``dax_apdb_deploy``.
 
 Cold Shutdown
 =============
 .. Any procedures needed to cleanly shutdown application before USDF downtime.
 
-Shutdown consusts of running ``down.yml`` playbook using a corresponding inventory.
+Shutdown consists of running ``down.yml`` playbook using a corresponding inventory.
 
 Reproduce Service
 =================
 .. How to reproduce service for testing purposes.
 
-``dax_apdb_deploy`` already has inventory and configuration for production and test clusters.
+``dax_apdb_deploy`` already has inventory and configuration for production, development (used for Prompt Production development), and integration clusters.
 Creating another Cassandra cluster would require finding a separate set of nodes with sufficient local storage.

--- a/docs/usdf-applications/ap/apdb/security.rst
+++ b/docs/usdf-applications/ap/apdb/security.rst
@@ -2,21 +2,82 @@
 Security
 ########
 
-To be completed...
 
 Requesting Access
 =================
 .. How to request access to the application.
 
+There are two types of access to APDB Cassandra service:
+
+- Regular APDB clients, which is an Alert Production pipeline.
+- Service management controlling the service itself.
+
+Regular clients access APDB through a Python API defined and implemented in ``dax_apdb`` package.
+Clients need to have credentials of a regular Cassandra account, these are defined in ``~/.lsst/db-auth.yaml`` file, its contents can be retrieved from the Vault.
+
+Management of APDB cluster is done via Ansible which uses SSH for connecting to cluster nodes.
+To be able to manage APDB services that run on Cassandra cluster nodes one needs to:
+
+- Have their Kerberos principal added to ``$HOME/.k5login`` of the service account on Cassandra nodes (see below). This is managed by USDF IT, send a message to ``usdf-help@slac.stanford.edu``.
+- Have their account enabled on all Cassandra cluster nodes and have ``sudo`` privileges, also managed by USDF IT.
+- Have access to the Vault secrets and a valid Kerberos ticket
+
+Cassandra nodes do not have shared home directories for users, to simplify access to the nodes it is advisable to create home directory on each Cassandra node and populate ``~/.k5login``.
+This can be done with Ansible from ``dax_apdb_deploy`` package, e.g. for ``prod`` cluster:
+
+.. code-block:: bash
+
+   # Create home directory on remote with correct ownership, directory is the same as on a local host.
+   ansible all -i inventory/apdb_prod.yaml -u $USER -b -K -m shell -a "mkdir -p ${HOME}; chown $USER ${HOME}"
+
+   # Create .k5login with user principal.
+   ansible all -i inventory/apdb_prod.yaml -u $USER -k -m shell -a "echo ${USER}@SLAC.STANFORD.EDU > ${HOME}/.k5login"
+
+And verify that SSH to any cluster host works without asking for a password after that.
+
 Service accounts
 ================
 .. Describe Kubernetes, Database, or Application Service accounts used by the application.
+
+All APDB services on each cluster node run in Docker containers, the service account ``rubincas`` manages those containers.
+This account is restricted to nodes dedicated to Cassandra clusters, USDF IT controls the setup of those nodes.
+
+The nodes belonging to Cassandra clusters do not use shared filesystem, the home directory for the service account (``/sdf/home/r/rubincas``) is created individually on each node.
+Access to the service account through SSH is controlled by ``$HOME/.k5login`` list which is populated by USDF Ansible scripts.
+
+Service accounts at USDF are not allowed to have ``sudo`` access, any operations that require ``sudo`` have to be executed from a regular user account.
+
+Deployment tools (``dax_apdb_deploy`` package) create two accounts in Cassandra:
+
+- Regular user account used by all APDB clients, e.g. ``apdb-prod`` account used by Prompt Production.
+  This account is allowed to create Cassandra keyspaces and do all sorts of regular CQL queries.
+- Cassandra superuser account that can control everything in Cassandra.
+- Default superuser ``cassandra`` account is disabled.
+
+The names and passwords for these two accounts have to be defined in the Vault before initializing the database.
+
+Exposed ports
+=============
+
+Cassandra service exposes port ``9042`` on each node of the cluster for regular client connections.
+Clients need proper credentials to connect to that port.
+
+For inter-cluster communication Cassandra uses port ``7000``.
+
+``cassandra-medusa`` service uses port ``*:50051`` for its gRPC API, no credentials required.
 
 
 Security Incident Response
 ==========================
 .. Information and procedures for handling security incidents.
 
+APDB traffic is restricted to USDF network.
+In case there is a security breach Cassandra clusters may need to be taken down.
+If there is a loss of data due to the incident, the cluster may need to be restored from backups.
+
 Security Policies
 =================
 .. Describe relevant policies related to the application or the data it processes.
+
+APDB itself and its data are considered internal to Alert Production pipeline and are not accessible to other users.
+APDB data is replicated to PPDB within a controlled delay where it is exposed to science users.

--- a/docs/usdf-applications/ap/apdb/security.rst
+++ b/docs/usdf-applications/ap/apdb/security.rst
@@ -16,11 +16,13 @@ Regular clients access APDB through a Python API defined and implemented in ``da
 Clients need to have credentials of a regular Cassandra account, these are defined in ``~/.lsst/db-auth.yaml`` file, its contents can be retrieved from the Vault.
 
 Management of APDB cluster is done via Ansible which uses SSH for connecting to cluster nodes.
-To be able to manage APDB services that run on Cassandra cluster nodes one needs to:
+To be able to manage APDB services that run on Cassandra cluster nodes one needs to :ref:`open a Service Now tickets <create_snow_request>`:
 
-- Have their Kerberos principal added to ``$HOME/.k5login`` of the service account on Cassandra nodes (see below). This is managed by USDF IT, send a message to ``usdf-help@slac.stanford.edu``.
-- Have their account enabled on all Cassandra cluster nodes and have ``sudo`` privileges, also managed by USDF IT.
-- Have access to the Vault secrets and a valid Kerberos ticket
+- to have their Kerberos principal added to ``$HOME/.k5login`` of the service account on Cassandra nodes (see below);
+- to have their account enabled on all Cassandra cluster nodes and have ``sudo`` privileges;
+- to have access to the Vault secrets.
+
+A valid Kerberos ticket needed for most operations when using ``dax_apdb_deploy`` tools, some also require authentication with the Vault (``vault login ...``).
 
 Cassandra nodes do not have shared home directories for users, to simplify access to the nodes it is advisable to create home directory on each Cassandra node and populate ``~/.k5login``.
 This can be done with Ansible from ``dax_apdb_deploy`` package, e.g. for ``prod`` cluster:

--- a/docs/usdf-applications/ap/apdb/troubleshooting.rst
+++ b/docs/usdf-applications/ap/apdb/troubleshooting.rst
@@ -23,17 +23,72 @@ Monitoring
 ==========
 .. Describe how to monitor application and include relevant links.
 
-`Dashboard for production Cassandra cluster <https://grafana.slac.stanford.edu/d/d7d52e6b-e376-49dc-8ef8-e4742dd229a9/cassandra-system-metrics?var-inter=1m&orgId=1&var-cluster=sdfk8sk00%5B1-6%5D&var-server=$__all>`_
+`Dashboard for production Cassandra cluster <https://grafana.slac.stanford.edu/d/d7d52e6b-e376-49dc-8ef8-e4742dd229a9/cassandra-system-metrics>`_ defines a number of graphs that reflect the state of the Cassandra and its host.
+It also includes logs for Cassandra and cassandra-medusa services with levels WARNING and ERROR.
 
-A number of alerts are defined there, alerts go to #ops-apdb-alerts Slack channel.
+Grafana dashboard defines a number of alerts for various conditions:
+
+- client connectivity failures, checked by a cron job every 10 minutes;
+- Cassandra monitoring updates, alarm raised when metrics stop to arrive;
+- Cassandra generates ``OutOfMemory`` exception;
+- ZFS pool status is different from ``ONLINE``.
+
+Alerts go to ``#ops-apdb-alerts`` Slack channel and a Pushover notification system of a responsible person.
+Grafana can generate alerts for the ``dev`` and ``int`` clusters as well, but those are less critical and may happen due to those clusters being temporarily down.
+
+A `separate Grafana dashboard <https://grafana.slac.stanford.edu/d/eescgnevzcwsga/pp-apdb-client-side-metrics?var-source=pp_apdb>`_ displays APDB-related metrics collected from Prompt Production clients.
+The data for that dashboard are extracted from log files in Loki by a cron job that runs every hour.
+
+Metrics from Cassandra hosts are sent to two InfluxDB servers:
+
+- ``influxdb.slac.stanford.edu`` for general OS metrics,
+- ``pp-influxdb.sdf.slac.stanford.edu`` - for Cassandra-specific metrics.
+
+If one or both of those servers experiences a failure, Grafana will generate an alert due to a missing metrics data.
+
+Logs from both Cassandra and Medusa services are sent to Loki, they can be retrieved with the query ``{compose_service="cassandra"}`` and ``{compose_service="medusa"}`` respectively.
+Only a subset of Cassandra logging messages is saved in Loki to avoid overloading that service.
+Recent Cassandra logs exist on each Cassandra node in folder ``/zfspool/cassandra/logs``.
 
 .. Template to use for troubleshooting
 
 Sample Troubleshooting
 ======================
 
-**Symptoms:**
+**Symptoms:** "Clients connection check" alert is raised but other metrics on dashboard look healthy.
 
-**Cause:**
+**Cause:** Occasionally cron jobs fail to run resulting in missing data.
 
-**Solution:**
+**Solution:** Check cron host (``sdfcron001``), if unhealthy report it to USDF support.
+
+----
+
+**Symptoms:** "ZFS pool status" alert is raised but other metrics on dashboard look healthy.
+
+**Cause:** One or more disks in ZFS pool have failed.
+
+**Solution:** Logon to the node, verify pool status (``zpool status``), report to USDF support. There were cases when after a reboot two disks were in OFFLINE state, this was caused by a flaky controller card, it needs to be re-seated.
+
+----
+
+**Symptoms:** "Cassandra OutOfMemoryError" alert is raised.
+
+**Cause:** Usually it is due to heavy load, e.g. too many concurrent jobs in a daily catch-up processing.
+
+**Solution:** If possible reduce the number of concurrent clients.
+
+----
+
+**Symptoms:** Multiple types of alerts from a single host.
+
+**Cause:** The host may be down or services fail to (re-)start.
+
+**Solution:** Try to connect to the host, if it is down report to USDF support. If services are down (``docker compose ps``), restart the services. If Cassandra is in a bad state (``nodetool status``) then restart the service.
+
+----
+
+**Symptoms:** Alerts are generated for multiple hosts, but cluster looks healthy.
+
+**Cause:** InfluxDB services may be down.
+
+**Solution:** Check the state of ``influxdb.slac.stanford.edu`` and ``pp-influxdbpp-influxdb.sdf.slac.stanford.edu``, report to USDF support if any service is not accessible.


### PR DESCRIPTION
Extended bunch of docs under `docs/usdf-applications/ap/apdb` with more useful info about Cassandra APDB service.